### PR TITLE
preserve leading spaces

### DIFF
--- a/proxy/bird.go
+++ b/proxy/bird.go
@@ -30,34 +30,16 @@ func birdReadln(bird io.Reader, w io.Writer) bool {
 	// print(string(c[:]))
 
 	// Remove preceding status number, different situations
-	if pos < 4 {
-		// Line is too short to have a status number
-		if w != nil {
-			pos = 0
-			for c[pos] == byte(' ') {
-				pos++
-			}
-			w.Write(c[pos:])
-		}
-		return true
-	} else if isNumeric(c[0]) && isNumeric(c[1]) && isNumeric(c[2]) && isNumeric(c[3]) {
+	if pos > 4 && isNumeric(c[0]) && isNumeric(c[1]) && isNumeric(c[2]) && isNumeric(c[3]) {
 		// There is a status number at beginning, remove first 5 bytes
 		if w != nil && pos > 6 {
 			pos = 5
-			for c[pos] == byte(' ') {
-				pos++
-			}
 			w.Write(c[pos:])
 		}
 		return c[0] != byte('0') && c[0] != byte('8') && c[0] != byte('9')
 	} else {
-		// There is no status number, only remove preceding spaces
 		if w != nil {
-			pos = 0
-			for c[pos] == byte(' ') {
-				pos++
-			}
-			w.Write(c[pos:])
+			w.Write(c[1:])
 		}
 		return true
 	}


### PR DESCRIPTION
Hi, I use only the proxy component of your project and noticed that it removes all leading spaces from the bird output. Since some things are easier to parse with indentation I'd like to preserve the leading spaces.

Output before: 

```
tralphium  BGP        ---        up     2020-11-16    Established
BGP state:          Established
Neighbor address: 2a0f:4ac0::3
Neighbor AS:      207921
Local AS:         207921
Neighbor ID:      195.39.247.3
Local capabilities
Multiprotocol
AF announced: ipv4 ipv6
Route refresh
Graceful restart
Restart time: 120
AF supported: ipv4 ipv6
AF preserved:
4-octet AS numbers
Enhanced refresh
Long-lived graceful restart
Neighbor capabilities
Multiprotocol
AF announced: ipv4 ipv6
Route refresh
Graceful restart
Restart time: 120
AF supported: ipv4 ipv6
AF preserved:
4-octet AS numbers
Enhanced refresh
Long-lived graceful restart
Session:          internal multihop AS4
Source address:   2a0f:4ac0:0:1::1
Hold timer:       228.944/240
Keepalive timer:  67.242/80
Channel ipv6
State:          UP
Table:          master6
Preference:     100
Input filter:   (unnamed)
Output filter:  (unnamed)
Routes:         99081 imported, 0 filtered, 94746 exported, 4357 preferred
Route change stats:     received   rejected   filtered    ignored   accepted
Import updates:        7574546          0          0    2425017    5149529
Import withdraws:       282399          0        ---        296     282103
Export updates:        4978407    1286938         38        ---    3691431
Export withdraws:       280289        ---        ---        ---     101911
BGP Next hop:   2a0f:4ac0:0:1::1
IGP IPv6 table: bgp6
Channel ipv4
State:          UP
Table:          master4
Preference:     100
Input filter:   (unnamed)
Output filter:  (unnamed)
Routes:         847011 imported, 0 filtered, 815225 exported, 31908 preferred
Route change stats:     received   rejected   filtered    ignored   accepted
Import updates:       21983691          0          0   12471122    9512569
Import withdraws:        93158          0        ---         34      93124
Export updates:       17387990    2274006          1        ---   15113983
Export withdraws:        82410        ---        ---        ---     735747
BGP Next hop:   127.0.0.1
IGP IPv4 table: bgp4
```

Output after:

```
tralphium  BGP        ---        up     2020-11-16    Established
  BGP state:          Established
    Neighbor address: 2a0f:4ac0::3
    Neighbor AS:      207921
    Local AS:         207921
    Neighbor ID:      195.39.247.3
    Local capabilities
      Multiprotocol
        AF announced: ipv4 ipv6
      Route refresh
      Graceful restart
        Restart time: 120
        AF supported: ipv4 ipv6
        AF preserved:
      4-octet AS numbers
      Enhanced refresh
      Long-lived graceful restart
    Neighbor capabilities
      Multiprotocol
        AF announced: ipv4 ipv6
      Route refresh
      Graceful restart
        Restart time: 120
        AF supported: ipv4 ipv6
        AF preserved:
      4-octet AS numbers
      Enhanced refresh
      Long-lived graceful restart
    Session:          internal multihop AS4
    Source address:   2a0f:4ac0:0:1::1
    Hold timer:       209.167/240
    Keepalive timer:  62.205/80
  Channel ipv6
    State:          UP
    Table:          master6
    Preference:     100
    Input filter:   (unnamed)
    Output filter:  (unnamed)
    Routes:         99077 imported, 0 filtered, 94746 exported, 4353 preferred
    Route change stats:     received   rejected   filtered    ignored   accepted
      Import updates:        7574670          0          0    2425021    5149649
      Import withdraws:       282403          0        ---        296     282107
      Export updates:        4978411    1286942         38        ---    3691431
      Export withdraws:       280293        ---        ---        ---     101911
    BGP Next hop:   2a0f:4ac0:0:1::1
    IGP IPv6 table: bgp6
  Channel ipv4
    State:          UP
    Table:          master4
    Preference:     100
    Input filter:   (unnamed)
    Output filter:  (unnamed)
    Routes:         847011 imported, 0 filtered, 815225 exported, 31908 preferred
    Route change stats:     received   rejected   filtered    ignored   accepted
      Import updates:       21983705          0          0   12471124    9512581
      Import withdraws:        93158          0        ---         34      93124
      Export updates:       17387990    2274006          1        ---   15113983
      Export withdraws:        82410        ---        ---        ---     735747
    BGP Next hop:   127.0.0.1
    IGP IPv4 table: bgp4
```