### PR TITLE
frontend: make domain optional

### DIFF
--- a/frontend/lgproxy.go
+++ b/frontend/lgproxy.go
@@ -35,7 +35,11 @@ func batchRequest(servers []string, endpoint string, command string) []string {
 			}(i)
 		} else {
 			// Compose URL and send the request
-			url := "http://" + server + "." + setting.domain + ":" + strconv.Itoa(setting.proxyPort) + "/" + url.PathEscape(endpoint) + "?q=" + url.QueryEscape(command)
+			hostname := server
+			if setting.domain != "" {
+				hostname += "." + setting.domain
+			}
+			url := "http://" + hostname + ":" + strconv.Itoa(setting.proxyPort) + "/" + url.PathEscape(endpoint) + "?q=" + url.QueryEscape(command)
 			go func(url string, i int) {
 				response, err := http.Get(url)
 				if err != nil {

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -80,8 +80,6 @@ func main() {
 
 	if *serversPtr == "" {
 		panic("no server set")
-	} else if *domainPtr == "" {
-		panic("no base domain set")
 	}
 
 	setting = settingType{


### PR DESCRIPTION
Making the domain optional allows usage of bare hostnames for the servers (e.g. when they're statically configured via /etc/hosts) and even IP addresses if one is so inclined (although presentation might suffer in this case).