### PR TITLE
Increase consistency of path escaping;  support IPv6 addresses

### DIFF
--- a/frontend/bindata/templates/page.tpl
+++ b/frontend/bindata/templates/page.tpl
@@ -33,8 +33,8 @@
 			</li>
 			{{ range $k, $v := .Servers }}
 			<li class="nav-item">
-				<a class="nav-link{{ if eq $server $v }} active{{ end }}"
-					href="/{{ $option }}/{{ $v }}/{{ $target }}">{{ html $v }}</a>
+				<a class="nav-link{{ if eq $server $k }} active{{ end }}"
+					href="/{{ $option }}/{{ $k }}/{{ $target }}">{{ html $v }}</a>
 			</li>
 			{{ end }}
 		</ul>

--- a/frontend/lgproxy.go
+++ b/frontend/lgproxy.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 type channelData struct {
@@ -36,6 +37,10 @@ func batchRequest(servers []string, endpoint string, command string) []string {
 		} else {
 			// Compose URL and send the request
 			hostname := server
+			hostname = url.PathEscape(hostname)
+			if strings.Contains(hostname, ":") {
+				hostname = "[" + hostname + "]"
+			}
 			if setting.domain != "" {
 				hostname += "." + setting.domain
 			}

--- a/frontend/render.go
+++ b/frontend/render.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -47,23 +48,28 @@ func renderPageTemplate(w http.ResponseWriter, r *http.Request, title string, co
 	// Use a default URL if the request URL is too short
 	// The URL is for return to summary page
 	if len(split) < 2 {
-		path = "summary/" + strings.Join(setting.servers, "+") + "/"
+		path = "summary/" + url.PathEscape(strings.Join(setting.servers, "+")) + "/"
 	} else if len(split) == 2 {
 		path += "/"
 	}
 
 	split = strings.SplitN(path, "/", 3)
 
+	serversEscaped := map[string]string{}
+	for _, v := range setting.servers {
+		serversEscaped[url.PathEscape(v)] = v
+	}
+
 	args := TemplatePage{
 		Options:              optionsMap,
-		Servers:              setting.servers,
+		Servers:              serversEscaped,
 		AllServersLinkActive: strings.ToLower(split[1]) == strings.ToLower(strings.Join(setting.servers, "+")),
-		AllServersURL:        strings.Join(setting.servers, "+"),
+		AllServersURL:        url.PathEscape(strings.Join(setting.servers, "+")),
 		IsWhois:              isWhois,
 		WhoisTarget:          whoisTarget,
 
 		URLOption:  strings.ToLower(split[0]),
-		URLServer:  strings.ToLower(split[1]),
+		URLServer:  url.PathEscape(strings.ToLower(split[1])),
 		URLCommand: split[2],
 		Title:      setting.titleBrand + title,
 		Brand:      setting.navBarBrand,

--- a/frontend/template.go
+++ b/frontend/template.go
@@ -11,7 +11,7 @@ import (
 type TemplatePage struct {
 	// Global options
 	Options map[string]string
-	Servers []string
+	Servers map[string]string
 
 	// Parameters related to current request
 	AllServersLinkActive bool

--- a/frontend/webserver.go
+++ b/frontend/webserver.go
@@ -71,12 +71,7 @@ func webBackendCommunicator(endpoint string, command string) func(w http.Respons
 		split := strings.SplitN(r.URL.Path[1:], "/", 3)
 		var urlCommands string
 		if len(split) >= 3 {
-			tmp, err := url.PathUnescape(split[2])
-			if err != nil {
-				serverError(w, r)
-				return
-			}
-			urlCommands = tmp
+			urlCommands = split[2]
 		}
 
 		var backendCommand string
@@ -87,12 +82,7 @@ func webBackendCommunicator(endpoint string, command string) func(w http.Respons
 		}
 		backendCommand = strings.TrimSpace(backendCommand)
 
-		escapedServers, err := url.PathUnescape(split[1])
-		if err != nil {
-			serverError(w, r)
-			return
-		}
-		servers := strings.Split(escapedServers, "+")
+		servers := strings.Split(split[1], "+")
 
 		var responses []string = batchRequest(servers, endpoint, backendCommand)
 		var content string
@@ -182,7 +172,7 @@ func webServerStart() {
 
 	// redirect main page to all server summary
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/summary/"+strings.Join(setting.servers, "+"), 302)
+		http.Redirect(w, r, "/summary/"+url.PathEscape(strings.Join(setting.servers, "+")), 302)
 	})
 
 	// serve static pages using the AssetFS and bindata


### PR DESCRIPTION
Thanks a lot for your project!
I had some trouble using IPv6 addresses. Here are the fixes needed to properly support them. I'd be happy to see them merged.

Description of changes in the pull request:
- webserver.go: "split := strings.SplitN(r.URL.Path[1:], "/", 3)" already contains unescaped path components; unescaping again leads to errors; therefore the additional unescaping is now removed
- lgproxy.go: escape the hostname before concatenating the url string; put IPv6 address (identified by containing a colon) into square brackets
- render.go: escape variables for use as path components; create a map of server names in the form "escapedPath: displayName"
- page.tpl: reflect change in "render.go"
- template.go: reflect change in "render.go"

With the changes above, one can use IPv6 addresses instead of hostnames when specifying servers. Due to the improved escaping, even link local addresses that contain the "%" character are supported now.
Example:  frontend --servers="hub.nodes,fe80::c%wg0" --domain=
