### PR TITLE
Allow specifying display names for servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ You can use source IP restriction to increase security. You should also bind the
 
 ## Advanced Features
 
+### Display names
+
+The server parameter is composed of server name prefixes, separated by comma. It also supports an extended syntax: It allows to define display names for the user interface that are different from the actual server names.
+
+For instance, the two servers from the basic example can be displayed as "Gigs" and "Hostdare" using the following syntax (as known from email addresses):
+
+    ./frontend --servers="Gigs<gigsgigscloud>,Hostdare<hostdare>" --domain=dn42.lantian.pub
+
+### IP addresses
+
+You may also specify IP addresses as server names when no domain is specified. IPv6 link local addresses are supported, too.
+
+For example:
+
+    ./frontend --servers="Prod<prod.mydomain.local>,Test1<fd88:dead:beef::1>,Test2<fe80::c%wg0>" --domain=
+
+These three servers are displayed as "Prod", "Test1" and "Test2" in the user interface. 
+
 ### API
 
 The frontend provides an API for running BIRD/traceroute/whois queries.

--- a/frontend/bindata/templates/page.tpl
+++ b/frontend/bindata/templates/page.tpl
@@ -31,10 +31,10 @@
 				<a class="nav-link{{ if .AllServersLinkActive }} active{{ end }}"
 					href="/{{ $option }}/{{ .AllServersURL }}/{{ $target }}"> All Servers </a>
 			</li>
-			{{ range $k, $v := .Servers }}
+			{{ range $k, $v := .ServersEscaped }}
 			<li class="nav-item">
-				<a class="nav-link{{ if eq $server $k }} active{{ end }}"
-					href="/{{ $option }}/{{ $k }}/{{ $target }}">{{ html $v }}</a>
+				<a class="nav-link{{ if eq $server $v }} active{{ end }}"
+					href="/{{ $option }}/{{ $v }}/{{ $target }}">{{ html (index $.ServersDisplay $k) }}</a>
 			</li>
 			{{ end }}
 		</ul>

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -12,6 +12,7 @@ import (
 
 type settingType struct {
 	servers         []string
+	serversDisplay  []string
 	domain          string
 	proxyPort       int
 	whoisServer     string
@@ -82,8 +83,21 @@ func main() {
 		panic("no server set")
 	}
 
+	servers := strings.Split(*serversPtr, ",")
+	serversDisplay := strings.Split(*serversPtr, ",")
+
+	// Split server names of the form "DisplayName<Hostname>"
+	for i, server := range servers {
+		pos := strings.Index(server, "<")
+		if pos != -1 {
+			serversDisplay[i] = server[0:pos]
+			servers[i] = server[pos+1:len(server)-1]
+		}
+	}
+
 	setting = settingType{
-		strings.Split(*serversPtr, ","),
+		servers,
+		serversDisplay,
 		*domainPtr,
 		*proxyPortPtr,
 		*whoisPtr,

--- a/frontend/render.go
+++ b/frontend/render.go
@@ -55,14 +55,16 @@ func renderPageTemplate(w http.ResponseWriter, r *http.Request, title string, co
 
 	split = strings.SplitN(path, "/", 3)
 
-	serversEscaped := map[string]string{}
-	for _, v := range setting.servers {
-		serversEscaped[url.PathEscape(v)] = v
+	serversEscaped := make([]string, len(setting.servers))
+	for i, v := range setting.servers {
+		serversEscaped[i] = url.PathEscape(v)
 	}
 
 	args := TemplatePage{
 		Options:              optionsMap,
-		Servers:              serversEscaped,
+		Servers:              setting.servers,
+		ServersEscaped:       serversEscaped,
+		ServersDisplay:       setting.serversDisplay,
 		AllServersLinkActive: strings.ToLower(split[1]) == strings.ToLower(strings.Join(setting.servers, "+")),
 		AllServersURL:        url.PathEscape(strings.Join(setting.servers, "+")),
 		IsWhois:              isWhois,

--- a/frontend/render_test.go
+++ b/frontend/render_test.go
@@ -10,6 +10,7 @@ import (
 
 func initSettings() {
 	setting.servers = []string{"alpha"}
+	setting.serversDisplay = []string{"alpha"}
 	setting.titleBrand = "Bird-lg Go"
 	setting.navBarBrand = "Bird-lg Go"
 

--- a/frontend/template.go
+++ b/frontend/template.go
@@ -11,7 +11,9 @@ import (
 type TemplatePage struct {
 	// Global options
 	Options map[string]string
-	Servers map[string]string
+	Servers []string
+	ServersEscaped []string
+	ServersDisplay []string
 
 	// Parameters related to current request
 	AllServersLinkActive bool

--- a/frontend/webserver.go
+++ b/frontend/webserver.go
@@ -95,9 +95,17 @@ func webBackendCommunicator(endpoint string, command string) func(w http.Respons
 				result = smartFormatter(response)
 			}
 
+			serverDisplay := servers[i]
+			for k, v := range setting.servers {
+				if servers[i] == v {
+					serverDisplay = setting.serversDisplay[k]
+					break
+				}
+			}
+
 			// render the bird result template
 			args := TemplateBird{
-				ServerName: servers[i],
+				ServerName: serverDisplay,
 				Target:     backendCommand,
 				Result:     result,
 			}


### PR DESCRIPTION
Allow specifying display names for servers. This addresses your comment from the previous pull request ("better representations on the UI").

The syntax follows what's known from email addresses (use of angle brackets).

Examples:
./frontend --servers="Gigs\<gigsgigscloud\>,Hostdare\<hostdare\>" --domain=dn42.lantian.pub
./frontend --servers="Prod\<prod.mydomain.local\>,Test1\<fd88:dead:beef::1\>,Test2\<fe80::c%wg0\>" --domain=

Especially useful when servers are specified by IP addresses. But also to provide nicknames, etc.

Description of changes in the pull request:

- page.tpl: Use ServersDisplay variable for displaying the servers
- template.go: Revert previous change to map since insertion order is lost; beside server names keep escaped server names and server display names in the template
- render.go: Reflect change in template.go
- webserver.go: Use server display names for Bird template
- main.go: Parse display names and remember in settings struct
- render_test.go: Adapt test initialization to reflect changes
- README.md: Document new possibilities under "Advanced Features" (to keep the "quickstart" simple)
