### PR TITLE
BGPmap improvements

### DIFF
--- a/frontend/bgpmap.go
+++ b/frontend/bgpmap.go
@@ -103,18 +103,16 @@ func birdRouteToGraphviz(servers []string, responses []string, target string) st
 
 			// First step starting from originating server
 			if len(paths) > 0 {
-				if len(routeNexthop) > 0 {
-					// Edge from originating server to nexthop
-					addEdge(server, "Nexthop:\\n"+routeNexthop, (map[bool]string{true: "[color=red]"})[routePreferred])
-					// and from nexthop to AS
-					addEdge("Nexthop:\\n"+routeNexthop, getASNRepresentation(paths[0]), (map[bool]string{true: "[color=red]"})[routePreferred])
-					addPoint("Nexthop:\\n"+routeNexthop, "[shape=diamond]")
-					routeFound = true
-				} else {
-					// Edge from originating server to AS
-					addEdge(server, getASNRepresentation(paths[0]), (map[bool]string{true: "[color=red]"})[routePreferred])
-					routeFound = true
+				routeFound = true
+				var attrs []string
+				if (routePreferred) {
+					attrs = append(attrs, "color=red")
 				}
+				if len(routeNexthop) > 0 {
+					attrs = append(attrs, fmt.Sprintf("label=\"Nexthop:\\n%s\"", routeNexthop))
+				}
+				formattedAttr := fmt.Sprintf("[%s]", strings.Join(attrs, ","))
+				addEdge(server, getASNRepresentation(paths[0]), formattedAttr)
 			}
 
 			// Following steps, edges between AS

--- a/frontend/bgpmap_test.go
+++ b/frontend/bgpmap_test.go
@@ -45,12 +45,10 @@ func TestBirdRouteToGraphviz(t *testing.T) {
 	BGP.next_hop: 172.18.0.2`
 
 	expectedResult := `digraph {
-"Nexthop:\n172.18.0.2" -> "AS4242422601" [color=red];
-"Nexthop:\n172.18.0.2" [shape=diamond];
 "AS4242422601" -> "Target: 192.168.0.1" [color=red];
 "Target: 192.168.0.1" [color=red,shape=diamond];
 "alpha" [color=blue,shape=box];
-"alpha" -> "Nexthop:\n172.18.0.2" [color=red];
+"alpha" -> "AS4242422601" [color=red,label="Nexthop:\\n172.18.0.2"];
 }`
 
 	result := birdRouteToGraphviz([]string{

--- a/frontend/bgpmap_test.go
+++ b/frontend/bgpmap_test.go
@@ -45,10 +45,10 @@ func TestBirdRouteToGraphviz(t *testing.T) {
 	BGP.next_hop: 172.18.0.2`
 
 	expectedResult := `digraph {
-"AS4242422601" -> "Target: 192.168.0.1" [color=red];
 "Target: 192.168.0.1" [color=red,shape=diamond];
 "alpha" [color=blue,shape=box];
-"alpha" -> "AS4242422601" [color=red,label="Nexthop:\\n172.18.0.2"];
+"alpha" -> "AS4242422601" [fontsize=12.0,color=red,label="alpha*\n172.18.0.2"];
+"AS4242422601" -> "Target: 192.168.0.1" [color=red];
 }`
 
 	result := birdRouteToGraphviz([]string{


### PR DESCRIPTION
- Add support for non-BGP routes, showing an edge from source to target with protocol name as label
- Move nexthop info from a separate node into the edge label
- Show the protocol name in edge labels to more easily differentiate between eBGP and iBGP sessions

Note: to implement non-BGP routes, I changed the split code from `"\t via"` to `"unicast"`, as static routes don't always include a `via 1.2.3.4` argument (in my case, they tend to use `dev <ifacename>` instead. This seems to work fine in my testing so far, but I'm not sure if there are other cases that this will miss.

Some before and after examples can be found at https://highdef.network/static/bgpmap-tweaks/index.html