### PR TITLE
frontend: limit fetched response size to 64KB

### DIFF
--- a/frontend/whois.go
+++ b/frontend/whois.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"time"
 )
@@ -19,9 +19,11 @@ func whois(s string) string {
 	defer conn.Close()
 
 	conn.Write([]byte(s + "\r\n"))
-	result, err := ioutil.ReadAll(conn)
-	if err != nil {
+
+	buf := make([]byte, 65536)
+	_, err = io.ReadFull(conn, buf)
+	if err != nil && err != io.ErrUnexpectedEOF {
 		return err.Error()
 	}
-	return string(result)
+	return string(buf)
 }


### PR DESCRIPTION
Temporary workaround against frontend consuming a lot of memory when processing large responses (like `show route all`).