### PR TITLE
frontend: add filtering by protocol type to summary tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Usage: all configuration is done via commandline parameters or environment varia
 | --title-brand | BIRDLG_TITLE_BRAND | prefix of page titles in browser tabs (default "Bird-lg Go") |
 | --navbar-brand | BIRDLG_NAVBAR_BRAND | brand to show in the navigation bar (default "Bird-lg Go") |
 | --net-specific-mode | BIRDLG_NET_SPECIFIC_MODE | apply network-specific changes for some networks, use "dn42" for BIRD in dn42 network |
-| --protocol-filter | BIRDLG_PROTOCOL_FILTER | case sensitive protocol types to show in summary tables (comma separated list); defaults to all if not set |
+| --protocol-filter | BIRDLG_PROTOCOL_FILTER | protocol types to show in summary tables (comma separated list); defaults to all if not set |
 
 Example: the following command starts the frontend with 2 BIRD nodes, with domain name "gigsgigscloud.dn42.lantian.pub" and "hostdare.dn42.lantian.pub", and proxies are running on port 8000 on both nodes.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Usage: all configuration is done via commandline parameters or environment varia
 | --title-brand | BIRDLG_TITLE_BRAND | prefix of page titles in browser tabs (default "Bird-lg Go") |
 | --navbar-brand | BIRDLG_NAVBAR_BRAND | brand to show in the navigation bar (default "Bird-lg Go") |
 | --net-specific-mode | BIRDLG_NET_SPECIFIC_MODE | apply network-specific changes for some networks, use "dn42" for BIRD in dn42 network |
+| --protocol-filter | BIRDLG_PROTOCOL_FILTER | case sensitive protocol types to show in summary tables (comma separated list); defaults to all if not set |
 
 Example: the following command starts the frontend with 2 BIRD nodes, with domain name "gigsgigscloud.dn42.lantian.pub" and "hostdare.dn42.lantian.pub", and proxies are running on port 8000 on both nodes.
 

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -86,7 +86,7 @@ func main() {
 	navBarBrandPtr := flag.String("navbar-brand", settingDefault.navBarBrand, "brand to show in the navigation bar")
 	telegramBotNamePtr := flag.String("telegram-bot-name", settingDefault.telegramBotName, "telegram bot name (used to filter @bot commands)")
 	protocolFilterPtr := flag.String("protocol-filter", strings.Join(settingDefault.protocolFilter, ","),
-		"case sensitive protocol types to show in summary tables (comma separated list); defaults to all if not set")
+		"protocol types to show in summary tables (comma separated list); defaults to all if not set")
 	flag.Parse()
 
 	if *serversPtr == "" {

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -19,6 +19,7 @@ type settingType struct {
 	titleBrand      string
 	navBarBrand     string
 	telegramBotName string
+	protocolFilter  []string
 }
 
 var setting settingType
@@ -33,6 +34,7 @@ func main() {
 		titleBrand:      "Bird-lg Go",
 		navBarBrand:     "Bird-lg Go",
 		telegramBotName: "",
+		protocolFilter:  []string{},
 	}
 
 	if env := os.Getenv("BIRDLG_SERVERS"); env != "" {
@@ -69,6 +71,9 @@ func main() {
 	if env := os.Getenv("BIRDLG_TELEGRAM_BOT_NAME"); env != "" {
 		settingDefault.telegramBotName = env
 	}
+	if env := os.Getenv("BIRDLG_PROTOCOL_FILTER"); env != "" {
+		settingDefault.protocolFilter = strings.Split(env, ",")
+	}
 
 	serversPtr := flag.String("servers", strings.Join(settingDefault.servers, ","), "server name prefixes, separated by comma")
 	domainPtr := flag.String("domain", settingDefault.domain, "server name domain suffixes")
@@ -80,6 +85,8 @@ func main() {
 	titleBrandPtr := flag.String("title-brand", settingDefault.titleBrand, "prefix of page titles in browser tabs")
 	navBarBrandPtr := flag.String("navbar-brand", settingDefault.navBarBrand, "brand to show in the navigation bar")
 	telegramBotNamePtr := flag.String("telegram-bot-name", settingDefault.telegramBotName, "telegram bot name (used to filter @bot commands)")
+	protocolFilterPtr := flag.String("protocol-filter", strings.Join(settingDefault.protocolFilter, ","),
+		"case sensitive protocol types to show in summary tables (comma separated list); defaults to all if not set")
 	flag.Parse()
 
 	if *serversPtr == "" {
@@ -88,6 +95,12 @@ func main() {
 
 	servers := strings.Split(*serversPtr, ",")
 	serversDisplay := strings.Split(*serversPtr, ",")
+
+	protocolFilter := []string{}
+	// strings.Split returns [""] for empty inputs; we want the list to remain empty in these cases
+	if len(*protocolFilterPtr) > 0 {
+		protocolFilter = strings.Split(*protocolFilterPtr, ",")
+	}
 
 	// Split server names of the form "DisplayName<Hostname>"
 	for i, server := range servers {
@@ -110,6 +123,7 @@ func main() {
 		*titleBrandPtr,
 		*navBarBrandPtr,
 		*telegramBotNamePtr,
+		protocolFilter,
 	}
 
 	ImportTemplates()

--- a/frontend/render.go
+++ b/frontend/render.go
@@ -156,6 +156,18 @@ func summaryParse(data string, serverName string) (TemplateSummary, error) {
 		}
 		if len(lineSplitted) >= 4 {
 			row.Proto = strings.TrimSpace(lineSplitted[3])
+			// Filter away unwanted protocol types, if setting.protocolFilter is non-empty
+			found := false
+			for _, protocol := range setting.protocolFilter {
+				if row.Proto == protocol {
+					found = true
+					break
+				}
+			}
+
+			if len(setting.protocolFilter) > 0 && !found {
+				continue
+			}
 		}
 		if len(lineSplitted) >= 6 {
 			row.Table = strings.TrimSpace(lineSplitted[5])

--- a/frontend/render.go
+++ b/frontend/render.go
@@ -159,7 +159,7 @@ func summaryParse(data string, serverName string) (TemplateSummary, error) {
 			// Filter away unwanted protocol types, if setting.protocolFilter is non-empty
 			found := false
 			for _, protocol := range setting.protocolFilter {
-				if row.Proto == protocol {
+				if strings.EqualFold(row.Proto, protocol) {
 					found = true
 					break
 				}

--- a/frontend/render_test.go
+++ b/frontend/render_test.go
@@ -77,3 +77,36 @@ func TestSummaryTableXSS(t *testing.T) {
 		t.Errorf("XSS injection succeeded: %s", result)
 	}
 }
+
+func TestSummaryTableProtocolFilter(t *testing.T) {
+	initSettings()
+	setting.protocolFilter = []string{"Static", "Direct", "Babel"}
+	data := `BIRD 2.0.8 ready.
+Name       Proto      Table      State  Since         Info
+static1    Static     master4    up     2021-08-27
+static2    Static     master6    up     2021-08-27
+device1    Device     ---        up     2021-08-27
+kernel1    Kernel     master6    up     2021-08-27
+kernel2    Kernel     master4    up     2021-08-27
+direct1    Direct     ---        up     2021-08-27
+int_babel  Babel      ---        up     2021-08-27    `
+
+	result := summaryTable(data, "testserver")
+	expectedInclude := []string{"static1", "static2", "int_babel", "direct1"}
+	expectedExclude := []string{"device1", "kernel1", "kernel2"}
+
+	for _, item := range expectedInclude {
+		if !strings.Contains(result, item) {
+			t.Errorf("Did not find expected %s in summary table output", result)
+		}
+	}
+	for _, item := range expectedExclude {
+		if strings.Contains(result, item) {
+			t.Errorf("Found unexpected %s in summary table output", result)
+		}
+	}
+
+	t.Cleanup(func() {
+		setting.protocolFilter = []string{}
+	})
+}


### PR DESCRIPTION
This adds a new option accessible via `-protocol-filter` and env var `BIRDLG_PROTOCOL_FILTER`, which configures a whitelist of protocol types to show in the summary table. (I think a whitelist should be enough for most use cases, as there's not too many possible values)

I've also added a corresponding test case.