### PR TITLE
1. remove ":" at the start of port assignement. 2. use BIRDLG_PROXY_P…

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,15 @@ Usage: all configuration is done via commandline parameters or environment varia
 | --------- | -------------------- | ----------- |
 | --servers | BIRDLG_SERVERS | server name prefixes, separated by comma |
 | --domain | BIRDLG_DOMAIN | server name domain suffixes |
-| --listen | BIRDLG_LISTEN | address bird-lg is listening on (default ":5000") |
+| --listen | BIRDLG_LISTEN | address bird-lg is listening on (default "5000") |
 | --proxy-port | BIRDLG_PROXY_PORT | port bird-lgproxy is running on (default 8000) |
 | --whois | BIRDLG_WHOIS | whois server for queries (default "whois.verisign-grs.com") |
 | --dns-interface | BIRDLG_DNS_INTERFACE | dns zone to query ASN information (default "asn.cymru.com") |
 | --title-brand | BIRDLG_TITLE_BRAND | prefix of page titles in browser tabs (default "Bird-lg Go") |
 | --navbar-brand | BIRDLG_NAVBAR_BRAND | brand to show in the navigation bar (default "Bird-lg Go") |
+| --navbar-brand-url | BIRDLG_NAVBAR_BRAND_URL | the url of the brand to show in the navigation bar (default "/") |
+| --navbar-all-servers | BIRDLG_NAVBAR_ALL_SERVERS | the text of "All servers" button in the navigation bar (default "ALL Servers") |
+| --navbar-all-url | BIRDLG_NAVBAR_ALL_URL | the URL of "All servers" button (default "all") |
 | --net-specific-mode | BIRDLG_NET_SPECIFIC_MODE | apply network-specific changes for some networks, use "dn42" for BIRD in dn42 network |
 | --protocol-filter | BIRDLG_PROTOCOL_FILTER | protocol types to show in summary tables (comma separated list); defaults to all if not set |
 
@@ -130,7 +133,7 @@ Usage: all configuration is done via commandline parameters or environment varia
 | --------- | -------------------- | ----------- |
 | --allowed | ALLOWED_IPS | IPs allowed to access this proxy, separated by commas. Don't set to allow all IPs. (default "") |
 | --bird | BIRD_SOCKET | socket file for bird, set either in parameter or environment variable BIRD_SOCKET (default "/var/run/bird/bird.ctl") |
-| --listen | BIRDLG_LISTEN | listen address, set either in parameter or environment variable BIRDLG_LISTEN (default ":8000") |
+| --listen | BIRDLG_PROXY_PORT | listen address, set either in parameter or environment variable  BIRDLG_PROXY_PORT(default "8000") |
 
 Example: start proxy with default configuration, should work "out of the box" on Debian 9 with BIRDv1:
 

--- a/frontend/assets/templates/page.tpl
+++ b/frontend/assets/templates/page.tpl
@@ -12,7 +12,7 @@
 <body>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
-	<a class="navbar-brand" href="/">{{ .Brand }}</a>
+	<a class="navbar-brand" href="{{ .BrandURL }}">{{ .Brand }}</a>
 	<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
 		<span class="navbar-toggler-icon"></span>
 	</button>
@@ -28,8 +28,13 @@
 		{{ end }}
 		<ul class="navbar-nav mr-auto">
 			<li class="nav-item">
+				{{ if eq .AllServersURLCustom "all" }}
 				<a class="nav-link{{ if .AllServersLinkActive }} active{{ end }}"
-					href="/{{ $option }}/{{ .AllServersURL }}/{{ $target }}"> All Servers </a>
+					href="/{{ $option }}/{{ .AllServersURL }}/{{ $target }}"> {{ .AllServerTitle }} </a>
+				{{ else }}
+				<a class="nav-link active"
+					href="{{ .AllServersURLCustom }}"> {{ .AllServerTitle }} </a>
+				{{ end }}
 			</li>
 			{{ range $k, $v := .ServersEscaped }}
 			<li class="nav-item">

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -18,6 +18,9 @@ type settingType struct {
 	netSpecificMode string
 	titleBrand      string
 	navBarBrand     string
+	navBarBrandURL  string
+	navBarAllServer string
+	navBarAllURL    string
 	telegramBotName string
 	protocolFilter  []string
 }
@@ -29,10 +32,13 @@ func main() {
 		servers:         []string{""},
 		proxyPort:       8000,
 		whoisServer:     "whois.verisign-grs.com",
-		listen:          ":5000",
+		listen:          "5000",
 		dnsInterface:    "asn.cymru.com",
 		titleBrand:      "Bird-lg Go",
 		navBarBrand:     "Bird-lg Go",
+		navBarBrandURL:  "/",
+		navBarAllServer: "All Servers",
+		navBarAllURL:    "all",
 		telegramBotName: "",
 		protocolFilter:  []string{},
 	}
@@ -68,6 +74,15 @@ func main() {
 	if env := os.Getenv("BIRDLG_NAVBAR_BRAND"); env != "" {
 		settingDefault.navBarBrand = env
 	}
+	if env := os.Getenv("BIRDLG_NAVBAR_BRAND_URL"); env != "" {
+		settingDefault.navBarBrandURL = env
+	}
+	if env := os.Getenv("BIRDLG_NAVBAR_ALL_SERVERS"); env != "" {
+		settingDefault.navBarAllServer = env
+	}
+	if env := os.Getenv("BIRDLG_NAVBAR_ALL_URL"); env != "" {
+		settingDefault.navBarAllURL = env
+	}
 	if env := os.Getenv("BIRDLG_TELEGRAM_BOT_NAME"); env != "" {
 		settingDefault.telegramBotName = env
 	}
@@ -84,6 +99,9 @@ func main() {
 	netSpecificModePtr := flag.String("net-specific-mode", settingDefault.netSpecificMode, "network specific operation mode, [(none)|dn42]")
 	titleBrandPtr := flag.String("title-brand", settingDefault.titleBrand, "prefix of page titles in browser tabs")
 	navBarBrandPtr := flag.String("navbar-brand", settingDefault.navBarBrand, "brand to show in the navigation bar")
+	navBarBrandURLPtr := flag.String("navbar-brand-url", settingDefault.navBarBrandURL, "brand to show in the navigation bar")
+	navBarAllServerPtr := flag.String("navbar-all-servers", settingDefault.navBarAllServer, "brand to show in the navigation bar")
+	navBarAllURL := flag.String("navbar-all-url", settingDefault.navBarAllURL, "brand to show in the navigation bar")
 	telegramBotNamePtr := flag.String("telegram-bot-name", settingDefault.telegramBotName, "telegram bot name (used to filter @bot commands)")
 	protocolFilterPtr := flag.String("protocol-filter", strings.Join(settingDefault.protocolFilter, ","),
 		"protocol types to show in summary tables (comma separated list); defaults to all if not set")
@@ -91,6 +109,11 @@ func main() {
 
 	if *serversPtr == "" {
 		panic("no server set")
+	}
+
+	if !strings.Contains(*listenPtr, ":") {
+		listenHost := ":" + (*listenPtr)
+		listenPtr = &listenHost
 	}
 
 	servers := strings.Split(*serversPtr, ",")
@@ -122,6 +145,9 @@ func main() {
 		strings.ToLower(*netSpecificModePtr),
 		*titleBrandPtr,
 		*navBarBrandPtr,
+		*navBarBrandURLPtr,
+		*navBarAllServerPtr,
+		*navBarAllURL,
 		*telegramBotNamePtr,
 		protocolFilter,
 	}

--- a/frontend/render.go
+++ b/frontend/render.go
@@ -67,6 +67,8 @@ func renderPageTemplate(w http.ResponseWriter, r *http.Request, title string, co
 		ServersDisplay:       setting.serversDisplay,
 		AllServersLinkActive: strings.ToLower(split[1]) == strings.ToLower(strings.Join(setting.servers, "+")),
 		AllServersURL:        url.PathEscape(strings.Join(setting.servers, "+")),
+		AllServerTitle:       setting.navBarAllServer,
+		AllServersURLCustom:  setting.navBarAllURL,
 		IsWhois:              isWhois,
 		WhoisTarget:          whoisTarget,
 
@@ -75,6 +77,7 @@ func renderPageTemplate(w http.ResponseWriter, r *http.Request, title string, co
 		URLCommand: split[2],
 		Title:      setting.titleBrand + title,
 		Brand:      setting.navBarBrand,
+		BrandURL:   setting.navBarBrandURL,
 		Content:    content,
 	}
 

--- a/frontend/template.go
+++ b/frontend/template.go
@@ -24,7 +24,9 @@ type TemplatePage struct {
 
 	// Parameters related to current request
 	AllServersLinkActive bool
+	AllServerTitle       string
 	AllServersURL        string
+	AllServersURLCustom  string
 
 	// Whois specific handling (for its unique URL)
 	IsWhois     bool
@@ -35,9 +37,10 @@ type TemplatePage struct {
 	URLCommand string
 
 	// Generated content to be displayed
-	Title   string
-	Brand   string
-	Content string
+	Title    string
+	Brand    string
+	BrandURL string
+	Content  string
 }
 
 // summary

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -3,6 +3,6 @@ module github.com/xddxdd/bird-lg-go/proxy
 go 1.15
 
 require (
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/handlers v1.5.1
 )

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -62,7 +62,7 @@ func main() {
 	// Prepare default socket paths, use environment variable if possible
 	var settingDefault = settingType{
 		"/var/run/bird/bird.ctl",
-		":8000",
+		"8000",
 		[]string{""},
 	}
 
@@ -72,15 +72,23 @@ func main() {
 	if listenEnv := os.Getenv("BIRDLG_LISTEN"); listenEnv != "" {
 		settingDefault.listen = listenEnv
 	}
+	if listenEnv := os.Getenv("BIRDLG_PROXY_PORT"); listenEnv != "" {
+		settingDefault.listen = listenEnv
+	}
 	if AllowedIPsEnv := os.Getenv("ALLOWED_IPS"); AllowedIPsEnv != "" {
 		settingDefault.allowedIPs = strings.Split(AllowedIPsEnv, ",")
 	}
 
 	// Allow parameters to override environment variables
 	birdParam := flag.String("bird", settingDefault.birdSocket, "socket file for bird, set either in parameter or environment variable BIRD_SOCKET")
-	listenParam := flag.String("listen", settingDefault.listen, "listen address, set either in parameter or environment variable BIRDLG_LISTEN")
+	listenParam := flag.String("listen", settingDefault.listen, "listen address, set either in parameter or environment variable BIRDLG_PROXY_PORT")
 	AllowedIPsParam := flag.String("allowed", strings.Join(settingDefault.allowedIPs, ","), "IPs allowed to access this proxy, separated by commas. Don't set to allow all IPs.")
 	flag.Parse()
+
+	if !strings.Contains(*listenParam, ":") {
+		listenHost := ":" + (*listenParam)
+		listenParam = &listenHost
+	}
 
 	setting.birdSocket = *birdParam
 	setting.listen = *listenParam


### PR DESCRIPTION
1. port不再需要放一個`:`在開頭了
    * 如果`:`不在字串裡面，就幫你補一個。可以相容以前的程式
2. proxy 現在用 BIRDLG_PROXY_PORT 而不是之前的 BIRDLG_LISTEN
    * 為了向前相容，先讀 BIRDLG_LISTEN 在讀 BIRDLG_PROXY_PORT 
    * 只有兩變數並存時會影響。但是以前的版本無法使用環境變數讓frontend/proxy運作在同一台電腦
    * 因為兩隻程式吃同一個變數，只能用參數。以前用參數的，現在還是用參數，所以應該不會影響舊版
![image](https://user-images.githubusercontent.com/73118488/134823864-11c81712-bf3b-43e6-a2ac-286dd0b61aae.png)
3. 新增這三個設定:
![image](https://user-images.githubusercontent.com/73118488/134824013-d3099943-9854-44d9-ad58-863482f26a1d.png)
![image](https://user-images.githubusercontent.com/73118488/134824030-4e834e7d-367a-4946-aaea-d7749274e9bc.png)
