### PR TITLE
Add BIRDLG_TRACEROUTE_RAW option to leave traceroute output in the default format

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Usage: all configuration is done via commandline parameters or environment varia
 | --bird | BIRD_SOCKET | socket file for bird, set either in parameter or environment variable BIRD_SOCKET (default "/var/run/bird/bird.ctl") |
 | --listen | BIRDLG_PROXY_PORT | listen address, set either in parameter or environment variable  BIRDLG_PROXY_PORT(default "8000") |
 | --traceroute_bin | BIRDLG_TRACEROUTE_BIN | traceroute binary file, set either in parameter or environment variable  BIRDLG_TRACEROUTE_BIN(default "traceroute") |
+| --traceroute_raw | BIRDLG_TRACEROUTE_RAW | whether to display traceroute outputs raw (default false) |
 
 Example: start proxy with default configuration, should work "out of the box" on Debian 9 with BIRDv1:
 

--- a/proxy/traceroute.go
+++ b/proxy/traceroute.go
@@ -81,14 +81,18 @@ func tracerouteHandler(httpW http.ResponseWriter, httpR *http.Request) {
 			httpW.Write([]byte(errString))
 		}
 		if result != nil {
-			errString = string(result)
-			errString = regexp.MustCompile(`(?m)^\s*(\d*)\s*\*\n`).ReplaceAllStringFunc(errString, func(w string) string {
-				skippedCounter++
-				return ""
-			})
-			httpW.Write([]byte(strings.TrimSpace(errString)))
-			if skippedCounter > 0 {
-				httpW.Write([]byte("\n\n" + strconv.Itoa(skippedCounter) + " hops not responding."))
+			if setting.tr_raw {
+				httpW.Write(result)
+			} else {
+				errString = string(result)
+				errString = regexp.MustCompile(`(?m)^\s*(\d*)\s*\*\n`).ReplaceAllStringFunc(errString, func(w string) string {
+					skippedCounter++
+					return ""
+				})
+				httpW.Write([]byte(strings.TrimSpace(errString)))
+				if skippedCounter > 0 {
+					httpW.Write([]byte("\n\n" + strconv.Itoa(skippedCounter) + " hops not responding."))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I wrote an [IRC frontend](https://github.com/jlu5/SupyPlugins/tree/master/BirdLGGo) for Bird-lg-go some time ago, with a custom parser to display `traceroute` output more compactly. However, I didn't realize at the time that Bird-lg-go uses its own format as well, leading the parsing results to be a bit inaccurate (it expects, for example, that destinations timing out have `*` at the end of the trace). Rather than change the code to fit bird-lg-go's format, I thought it'd be useful and more portable to optionally provide the raw traceroute output instead.
