### PR TITLE
 Add name filter feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Usage: all configuration is done via commandline parameters or environment varia
 | --navbar-all-url | BIRDLG_NAVBAR_ALL_URL | the URL of "All servers" button (default "all") |
 | --net-specific-mode | BIRDLG_NET_SPECIFIC_MODE | apply network-specific changes for some networks, use "dn42" for BIRD in dn42 network |
 | --protocol-filter | BIRDLG_PROTOCOL_FILTER | protocol types to show in summary tables (comma separated list); defaults to all if not set |
+| --name-filter | BIRDLG_NAME_FILTER | protocol names to hide in summary tables (RE2 syntax); defaults to none if not set |
 
 Example: the following command starts the frontend with 2 BIRD nodes, with domain name "gigsgigscloud.dn42.lantian.pub" and "hostdare.dn42.lantian.pub", and proxies are running on port 8000 on both nodes.
 

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -24,6 +24,7 @@ type settingType struct {
 	bgpmapInfo      string
 	telegramBotName string
 	protocolFilter  []string
+	nameFilter      string
 }
 
 var setting settingType
@@ -43,6 +44,7 @@ func main() {
 		bgpmapInfo:      "asn,as-name,ASName,descr",
 		telegramBotName: "",
 		protocolFilter:  []string{},
+		nameFilter:      "",
 	}
 
 	if env := os.Getenv("BIRDLG_SERVERS"); env != "" {
@@ -94,6 +96,9 @@ func main() {
 	if env := os.Getenv("BIRDLG_PROTOCOL_FILTER"); env != "" {
 		settingDefault.protocolFilter = strings.Split(env, ",")
 	}
+	if env := os.Getenv("BIRDLG_NAME_FILTER"); env != "" {
+		settingDefault.nameFilter = env
+	}
 
 	serversPtr := flag.String("servers", strings.Join(settingDefault.servers, ","), "server name prefixes, separated by comma")
 	domainPtr := flag.String("domain", settingDefault.domain, "server name domain suffixes")
@@ -111,6 +116,7 @@ func main() {
 	telegramBotNamePtr := flag.String("telegram-bot-name", settingDefault.telegramBotName, "telegram bot name (used to filter @bot commands)")
 	protocolFilterPtr := flag.String("protocol-filter", strings.Join(settingDefault.protocolFilter, ","),
 		"protocol types to show in summary tables (comma separated list); defaults to all if not set")
+	nameFilterPtr := flag.String("name-filter", settingDefault.nameFilter, "protocol name regex to hide in summary tables (RE2 syntax); defaults to none if not set")
 	flag.Parse()
 
 	if *serversPtr == "" {
@@ -157,6 +163,7 @@ func main() {
 		*bgpmapInfo,
 		*telegramBotNamePtr,
 		protocolFilter,
+		*nameFilterPtr,
 	}
 
 	ImportTemplates()

--- a/frontend/render.go
+++ b/frontend/render.go
@@ -133,6 +133,9 @@ func summaryParse(data string, serverName string) (TemplateSummary, error) {
 		args.Header = append(args.Header, col)
 	}
 
+	// Build regexp for nameFilter
+	nameFilterRegexp := regexp.MustCompile(setting.nameFilter)
+
 	// sort the remaining rows
 	rows := lines[1:]
 	sort.Strings(rows)
@@ -156,6 +159,9 @@ func summaryParse(data string, serverName string) (TemplateSummary, error) {
 
 		if len(lineSplitted) >= 2 {
 			row.Name = strings.TrimSpace(lineSplitted[1])
+			if setting.nameFilter != "" && nameFilterRegexp.MatchString(row.Name) {
+				continue
+			}
 		}
 		if len(lineSplitted) >= 4 {
 			row.Proto = strings.TrimSpace(lineSplitted[3])

--- a/frontend/render_test.go
+++ b/frontend/render_test.go
@@ -110,3 +110,36 @@ int_babel  Babel      ---        up     2021-08-27    `
 		setting.protocolFilter = []string{}
 	})
 }
+
+func TestSummaryTableNameFilter(t *testing.T) {
+	initSettings()
+	setting.nameFilter = "^static"
+	data := `BIRD 2.0.8 ready.
+Name       Proto      Table      State  Since         Info
+static1    Static     master4    up     2021-08-27
+static2    Static     master6    up     2021-08-27
+device1    Device     ---        up     2021-08-27
+kernel1    Kernel     master6    up     2021-08-27
+kernel2    Kernel     master4    up     2021-08-27
+direct1    Direct     ---        up     2021-08-27
+int_babel  Babel      ---        up     2021-08-27    `
+
+	result := summaryTable(data, "testserver")
+	expectedInclude := []string{"device1", "kernel1", "kernel2", "direct1", "int_babel"}
+	expectedExclude := []string{"static1", "static2"}
+
+	for _, item := range expectedInclude {
+		if !strings.Contains(result, item) {
+			t.Errorf("Did not find expected %s in summary table output", result)
+		}
+	}
+	for _, item := range expectedExclude {
+		if strings.Contains(result, item) {
+			t.Errorf("Found unexpected %s in summary table output", result)
+		}
+	}
+
+	t.Cleanup(func() {
+		setting.nameFilter = ""
+	})
+}


### PR DESCRIPTION
 This uses a RE2 regexp to hide protocols which name matches the expression

(Obviously it would be better to completely prevent queries on protocols matching the filter, but it's a start I think)