### PR TITLE
settings: treat empty environment variables as set

### DIFF
--- a/frontend/settings.go
+++ b/frontend/settings.go
@@ -33,6 +33,7 @@ func parseSettings() {
 	viper.AddConfigPath(".")
 	viper.AddConfigPath("/etc/bird-lg")
 	viper.SetConfigName("bird-lg")
+	viper.AllowEmptyEnv(true)
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("birdlg")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))

--- a/proxy/settings.go
+++ b/proxy/settings.go
@@ -23,6 +23,7 @@ func parseSettings() {
 	viper.AddConfigPath(".")
 	viper.AddConfigPath("/etc/bird-lg")
 	viper.SetConfigName("bird-lgproxy")
+	viper.AllowEmptyEnv(true)
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("birdlg")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))


### PR DESCRIPTION
This allows disabling specific options like dns_interface or whois via environment variables.

ref: https://github.com/spf13/viper#working-with-environment-variables