### PR TITLE
Properly escape server in html form

### DIFF
--- a/frontend/assets/templates/page.tpl
+++ b/frontend/assets/templates/page.tpl
@@ -60,7 +60,7 @@
 					<option value="{{ html $k }}"{{ if eq $k $.URLOption }} selected{{end}}>{{ html $v }}</option>
 					{{ end }}
 				</select>
-				<input name="server" class="d-none" value="{{ html $server }}">
+				<input name="server" class="d-none" value="{{ html ($server | pathescape) }}">
 				<input name="target" class="form-control" placeholder="Target" aria-label="Target" value="{{ html $target }}">
 				<div class="input-group-append">
 					<button class="btn btn-outline-success" type="submit">&raquo;</button>

--- a/frontend/template.go
+++ b/frontend/template.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"html/template"
+        "net/url"
 	"strings"
 )
 
@@ -104,6 +105,12 @@ var requiredTemplates = [...]string{
 	"bird",
 }
 
+// define functions to be made available in templates
+
+var funcMap = template.FuncMap{
+        "pathescape": url.PathEscape,
+}
+
 // import templates from embedded assets
 
 func ImportTemplates() {
@@ -121,7 +128,7 @@ func ImportTemplates() {
 		}
 
 		// and add it to the template library
-		template, err := template.New(tmpl).Parse(string(def))
+		template, err := template.New(tmpl).Funcs(funcMap).Parse(string(def))
 		if err != nil {
 			panic("Unable to parse template (" + TEMPLATE_PATH + tmpl + ": " + err.Error())
 		}


### PR DESCRIPTION
This is a bugfix:

Previous behavior: When pushing the form button in the upper right of the page, the server is not getting escaped properly. This is an issue when an IPv6 link local address like "fe80::1234%myinterface" is the server.
Example: When pushing the html form button after selecting the action and specifying the parameter, a URL like "http://myserver.local/route_where/fe80::10%tlwg_mgmt/192.168.4.0/24" is called. This results in a "400 Bad Request" output.

Corrected behavior:
The server gets escaped to "fe80::1234%25myinterface" when pushing the html form button - consistent to the other links.
Example: When pushing the html form button, a URL like "http://myserver.local/route_where/fe80::10%25tlwg_mgmt/192.168.4.0/24" is working perfectly.

Comment on the code change:
Since the needed url.PathEscape is not available in templating by default, it is provided as a custom function.

Thanks for maintaining bird-lg-go and thanks in advance for merging this fix.