### PR TITLE
Enable proxy to allow access by CIDR network as well as IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Configuration is handled by [viper](https://github.com/spf13/viper), any config 
 
 | Config Key | Parameter | Environment Variable | Description |
 | ---------- | --------- | -------------------- | ----------- |
-| allowed_ips | --allowed | ALLOWED_IPS | IPs allowed to access this proxy, separated by commas. Don't set to allow all IPs. (default "") |
+| allowed_ips | --allowed | ALLOWED_IPS | IPs or networks allowed to access this proxy, separated by commas. Don't set to allow all IPs. (default "") |
 | bird_socket | --bird | BIRD_SOCKET | socket file for bird, set either in parameter or environment variable BIRD_SOCKET (default "/var/run/bird/bird.ctl") |
 | listen | --listen | BIRDLG_PROXY_PORT | listen address, set either in parameter or environment variable  BIRDLG_PROXY_PORT(default "8000") |
 | traceroute_bin | --traceroute_bin | BIRDLG_TRACEROUTE_BIN | traceroute binary file, set either in parameter or environment variable  BIRDLG_TRACEROUTE_BIN |

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -22,8 +22,8 @@ func invalidHandler(httpW http.ResponseWriter, httpR *http.Request) {
 }
 
 func hasAccess(remoteAddr string) bool {
-	// setting.allowedIPs will always have at least one element because of how it's defined
-	if len(setting.allowedIPs) == 0 {
+	// setting.allowedNets will always have at least one element because of how it's defined
+	if len(setting.allowedNets) == 0 {
 		return true
 	}
 
@@ -40,8 +40,8 @@ func hasAccess(remoteAddr string) bool {
 		return false
 	}
 
-	for _, allowedIP := range setting.allowedIPs {
-		if ipObject.Equal(allowedIP) {
+	for _, net := range setting.allowedNets {
+		if net.Contains(ipObject) {
 			return true
 		}
 	}
@@ -49,7 +49,7 @@ func hasAccess(remoteAddr string) bool {
 	return false
 }
 
-// Access handler, check to see if client IP in allowed IPs, continue if it is, send to invalidHandler if not
+// Access handler, check to see if client IP in allowed nets, continue if it is, send to invalidHandler if not
 func accessHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(httpW http.ResponseWriter, httpR *http.Request) {
 		if hasAccess(httpR.RemoteAddr) {
@@ -61,12 +61,12 @@ func accessHandler(next http.Handler) http.Handler {
 }
 
 type settingType struct {
-	birdSocket string
-	listen     string
-	allowedIPs []net.IP
-	tr_bin     string
-	tr_flags   []string
-	tr_raw     bool
+	birdSocket  string
+	listen      string
+	allowedNets []*net.IPNet
+	tr_bin      string
+	tr_flags    []string
+	tr_raw      bool
 }
 
 var setting settingType

--- a/proxy/main_test.go
+++ b/proxy/main_test.go
@@ -10,42 +10,61 @@ import (
 )
 
 func TestHasAccessNotConfigured(t *testing.T) {
-	setting.allowedIPs = []net.IP{}
+	setting.allowedNets = []*net.IPNet{}
 	assert.Equal(t, hasAccess("whatever"), true)
 }
 
 func TestHasAccessAllowIPv4(t *testing.T) {
-	setting.allowedIPs = []net.IP{net.ParseIP("1.2.3.4")}
+	_, netip, _ := net.ParseCIDR("1.2.3.4/32")
+	setting.allowedNets = []*net.IPNet{netip}
+	assert.Equal(t, hasAccess("1.2.3.4:4321"), true)
+}
+
+func TestHasAccessAllowIPv4Net(t *testing.T) {
+	_, netip, _ := net.ParseCIDR("1.2.3.0/24")
+	setting.allowedNets = []*net.IPNet{netip}
 	assert.Equal(t, hasAccess("1.2.3.4:4321"), true)
 }
 
 func TestHasAccessDenyIPv4(t *testing.T) {
-	setting.allowedIPs = []net.IP{net.ParseIP("4.3.2.1")}
+	_, netip, _ := net.ParseCIDR("4.3.2.1/32")
+	setting.allowedNets = []*net.IPNet{netip}
 	assert.Equal(t, hasAccess("1.2.3.4:4321"), false)
 }
 
 func TestHasAccessAllowIPv6(t *testing.T) {
-	setting.allowedIPs = []net.IP{net.ParseIP("2001:db8::1")}
+	_, netip, _ := net.ParseCIDR("2001:db8::1/128")
+	setting.allowedNets = []*net.IPNet{netip}
+	assert.Equal(t, hasAccess("[2001:db8::1]:4321"), true)
+}
+
+func TestHasAccessAllowIPv6Net(t *testing.T) {
+	_, netip, _ := net.ParseCIDR("2001:db8::/64")
+	setting.allowedNets = []*net.IPNet{netip}
 	assert.Equal(t, hasAccess("[2001:db8::1]:4321"), true)
 }
 
 func TestHasAccessAllowIPv6DifferentForm(t *testing.T) {
-	setting.allowedIPs = []net.IP{net.ParseIP("2001:0db8::1")}
+	_, netip, _ := net.ParseCIDR("2001:db8::1/128")
+	setting.allowedNets = []*net.IPNet{netip}
 	assert.Equal(t, hasAccess("[2001:db8::1]:4321"), true)
 }
 
 func TestHasAccessDenyIPv6(t *testing.T) {
-	setting.allowedIPs = []net.IP{net.ParseIP("2001:db8::2")}
+	_, netip, _ := net.ParseCIDR("2001:db8::2/128")
+	setting.allowedNets = []*net.IPNet{netip}
 	assert.Equal(t, hasAccess("[2001:db8::1]:4321"), false)
 }
 
 func TestHasAccessBadClientIP(t *testing.T) {
-	setting.allowedIPs = []net.IP{net.ParseIP("1.2.3.4")}
+	_, netip, _ := net.ParseCIDR("1.2.3.4/32")
+	setting.allowedNets = []*net.IPNet{netip}
 	assert.Equal(t, hasAccess("not an IP"), false)
 }
 
 func TestHasAccessBadClientIPPort(t *testing.T) {
-	setting.allowedIPs = []net.IP{net.ParseIP("1.2.3.4")}
+	_, netip, _ := net.ParseCIDR("1.2.3.4/32")
+	setting.allowedNets = []*net.IPNet{netip}
 	assert.Equal(t, hasAccess("not an IP:not a port"), false)
 }
 
@@ -57,7 +76,8 @@ func TestAccessHandlerAllow(t *testing.T) {
 	r.RemoteAddr = "1.2.3.4:4321"
 	w := httptest.NewRecorder()
 
-	setting.allowedIPs = []net.IP{net.ParseIP("1.2.3.4")}
+	_, netip, _ := net.ParseCIDR("1.2.3.4/32")
+	setting.allowedNets = []*net.IPNet{netip}
 
 	wrappedHandler.ServeHTTP(w, r)
 	assert.Equal(t, w.Code, http.StatusNotFound)
@@ -71,7 +91,8 @@ func TestAccessHandlerDeny(t *testing.T) {
 	r.RemoteAddr = "1.2.3.4:4321"
 	w := httptest.NewRecorder()
 
-	setting.allowedIPs = []net.IP{net.ParseIP("4.3.2.1")}
+	_, netip, _ := net.ParseCIDR("4.3.2.1/32")
+	setting.allowedNets = []*net.IPNet{netip}
 
 	wrappedHandler.ServeHTTP(w, r)
 	assert.Equal(t, w.Code, http.StatusInternalServerError)


### PR DESCRIPTION
This is a small tweak to enable use of CIDR networks as well as IP address when allowing access to the proxy. This is so you can have a trusted network rather then have to specify lots of specific IP addresses.